### PR TITLE
Update URLS and dates for 2025 Oct edition

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ The course does not aim to provide a course in specific spatial analysis and sta
 
 ## Getting started
 
-The course uses Python 3, data analysis packages such as Pandas, Numpy and Matplotlib and geospatial packages such as GeoPandas, Rasterio and Xarray. To install the required libraries, we highly recommend Anaconda or miniconda (<https://www.anaconda.com/download/>) or another Python distribution that includes the scientific libraries (this recommendation applies to all platforms, so for both Window, Linux and Mac).
+The course uses Python 3, data analysis packages such as Pandas, Numpy and Matplotlib and geospatial packages such as GeoPandas and Xarray. To install the required libraries, we recommend Anaconda or miniconda or another Python distribution that includes the scientific libraries (this recommendation applies to all platforms, so for both Window, Linux and Mac).
 
-For detailed instructions to get started on your local machine , see the [setup instructions](./setup.md).
+For detailed instructions to get started on your local machine , see the [setup instructions](./docs/setup.md).
 
-In case you do not want to install everything and just want to try out the course material, use the environment setup by Binder [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/jorisvandenbossche/DS-python-geospatial/HEAD?urlpath=lab/tree/notebooks) and open de notebooks rightaway.
+In case you do not want to install everything and just want to try out the course material, use the environment setup by Binder [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/plovercode/DS-python-geospatial/HEAD?urlpath=lab/tree/notebooks) and open de notebooks rightaway.
 
 
 ## Contributing

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -16,18 +16,17 @@ Think this course is useful? Let others discover it, by telling them in person, 
 
 ### Ask a question ⁉️
 
-Trying out the material and got stuck? Post your question as an [issue on GitHub](https://github.com/jorisvandenbossche/course-python-geospatial/issues). While we cannot offer user support, we'll try to do our best to address it, as questions often lead to the discovery of bugs.
+Trying out the material and got stuck? Post your question as an [issue on GitHub](https://github.com/plovercode/course-python-geospatial/issues). While we cannot offer user support, we'll try to do our best to address it, as questions often lead to the discovery of bugs.
 
 Want to ask a question in private? Contact the course maintainer by [email](jorisvandenbossche@gmail.com).
 
 ### Propose an idea 💡
 
-Have an idea for to improve the course? Take a look at the [issue list](https://github.com/jorisvandenbossche/course-python-geospatial/issues) to see if it isn't included or suggested yet. If not, suggest your idea as an [issue on GitHub](https://github.com/jorisvandenbossche/course-python-geospatial/issues/new).
+Have an idea for to improve the course? Take a look at the [issue list](https://github.com/plovercode/course-python-geospatial/issues) to see if it isn't included or suggested yet. If not, suggest your idea as an [issue on GitHub](https://github.com/plovercode/course-python-geospatial/issues/new).
 
 ### Report a bug 🐛
 
-Using the course and discovered a bug or a typo? That's annoying! Don't let others have the same experience and report it as an [issue on GitHub](https://github.com/jorisvandenbossche/Have an idea for to improve the course? Take a look at the [issue list](https://github.com/jorisvandenbossche/course-python-geospatial/issues) to see if it isn't included or suggested yet. If not, suggest your idea as an [issue on GitHub](https://github.com/jorisvandenbossche/course-python-geospatial/issues/new).
-/issues/new) so we can fix it. A good bug report makes it easier for us to do so, so please include:
+Using the course and discovered a bug or a typo? That's annoying! Don't let others have the same experience and report it as an [issue on GitHub](https://github.com/plovercode/DS-python-geospatial/issues) so we can fix it. A good bug report makes it easier for us to do so, so please include:
 
 * Your operating system name and version (e.g. Mac OS 10.13.6).
 * Any details about your local setup that might be helpful in troubleshooting.
@@ -39,7 +38,7 @@ Care to fix issues or typo's? Awesome! 👏
 
 Some notes to take into account:
 
-- The course material is developed in the [course-python-geospatial](https://github.com/jorisvandenbossche/course-python-geospatial) repository. When updating course material, edit the notebooks in the [course-python-geospatial](https://github.com/jorisvandenbossche/course-python-geospatial) repository, the other ones (the ones used in the tutorial) are generated automatically.
+- The course material is developed in the [course-python-geospatial](https://github.com/plovercode/course-python-geospatial) repository. When updating course material, edit the notebooks in the [course-python-geospatial](https://github.com/plovercode/course-python-geospatial) repository, the other ones (the ones used in the tutorial) are generated automatically.
 - the exercises are cleared using the `nbtutor` notebook extension: <https://github.com/jorisvandenbossche/nbtutor>
 
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,19 +27,18 @@ In the last part, the use of xarray for spatial data cubes (netcdf-like), out-of
 
 ## Getting started
 
-The course uses Python 3 and some data analysis packages such as Pandas, Numpy and Matplotlib and geospatial packages such as GeoPandas, Rasterio and Xarray. To install the required libraries,
-we recommend Anaconda or miniconda ([https://www.anaconda.com/download/](https://www.anaconda.com/download/)) or another Python distribution that
+The course uses Python 3 and some data analysis packages such as Pandas, Numpy and Matplotlib and geospatial packages such as GeoPandas and Xarray. To install the required libraries, we recommend Miniconda or another Python distribution that
 includes the scientific libraries (this recommendation applies to all platforms, so for both Window, Linux and Mac).
 
 For detailed instructions to get started on your local machine, see the [setup instructions](./setup.html).
 
 In case you do not want to install everything and just want to try out the course material, use the environment setup by
-Binder [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/jorisvandenbossche/DS-python-geospatial/HEAD) and open de notebooks
+Binder [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/plovercode/DS-python-geospatial/HEAD) and open de notebooks
 rightaway (inside the `notebooks` directory).
 
 ## Slides
 
-For the course slides, click [here](https://jorisvandenbossche.github.io/DS-python-geospatial/slides.html).
+For the course slides, click [here](https://plovercode.github.io/DS-python-geospatial/slides.html).
 
 ## Contributing
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -17,11 +17,11 @@ In the following sections, more details are provided for each of these steps. Wh
 
 ### Option 1: You are already a git user
 
-As the course has been set up as a [git](https://git-scm.com/) repository managed on [Github](https://github.com/jorisvandenbossche/DS-python-geospatial),
+As the course has been set up as a [git](https://git-scm.com/) repository managed on [Github](https://github.com/plovercode/DS-python-geospatial),
 you can clone the entire course to your local machine. Use the command line to clone the repository and go into the course folder:
 
 ```
-git clone https://github.com/jorisvandenbossche/DS-python-geospatial.git
+git clone https://github.com/plovercode/DS-python-geospatial.git
 cd DS-python-geospatial
 ```
 
@@ -31,7 +31,7 @@ see [this tutorial](https://help.github.com/desktop/guides/contributing-to-proje
 ### Option 2: You are not a git user
 
 To download the repository to your local machine as a zip-file, click the  `download ZIP` on the
-repository page <https://github.com/jorisvandenbossche/DS-python-geospatial> (green button "Code"):
+repository page <https://github.com/plovercode/DS-python-geospatial> (green button "Code"):
 
 ![Download button](./static/img/download-button.png)
 
@@ -86,7 +86,7 @@ throughout this course.
 As a good practice, we will create a new _conda environment_ to work with.
 
 The packages used in the course are enlisted in
-an [`environment.yml` file](https://raw.githubusercontent.com/jorisvandenbossche/DS-python-geospatial/main/environment.yml). The file looks as follows:
+an [`environment.yml` file](https://raw.githubusercontent.com/plovercode/DS-python-geospatial/main/environment.yml). The file looks as follows:
 
 ```
 name: DS-geospatial

--- a/docs/slides.html
+++ b/docs/slides.html
@@ -13,20 +13,20 @@ class: center, middle
 # Python for GIS and Geoscience
 
 Doctoral schools of Ghent University<br>
-December 12, 16 and 19, 2024
+Ooctober 13, 16 and 19, 2025
 
 Joris Van den Bossche, Stijn Van Hoey
 
-https://github.com/jorisvandenbossche/DS-python-geospatial
+https://github.com/plovercode/DS-python-geospatial
 
 ---
 class: center, middle
 
 # Who are you?
 
-Go to https://hackmd.io/GaohdyaETeuUAI1F8sjXPw?both
+Go to https://hackmd.io/1bcxgBFIRP28vgyMSZMaBg?both
 
-<iframe src="https://hackmd.io/GaohdyaETeuUAI1F8sjXPw?both" height="400px" width="800px"></iframe>
+<iframe src="https://hackmd.io/1bcxgBFIRP28vgyMSZMaBg?both" height="400px" width="800px"></iframe>
 
 ---
 
@@ -44,7 +44,7 @@ Go to https://hackmd.io/GaohdyaETeuUAI1F8sjXPw?both
 <a href="https://github.com/stijnvanhoey"><img src="./static/img/icon_github.svg" alt="Github logo"> stijnvanhoey</a>
 
 * Freelance developer and teacher
-* Research software engineer at [Fluves](https://www.fluves.com/)
+* IT Team Lead at [Fluves](https://www.fluves.com/)
 
 .center[
 ![:scale 90%](./static/img/work_stijn_1.png)]
@@ -58,19 +58,19 @@ class: middle, section_background
 
 ## Setting up a working environment
 
-For the setup instructions, see the [setup page](https://jorisvandenbossche.github.io/DS-python-geospatial/setup.html).
+For the setup instructions, see the [setup page](https://plovercode.github.io/DS-python-geospatial/setup.html).
 
 ---
 class: left, middle
 
-0. If not already downloaded the course material, installed conda and setup the environment, see [setup instructions section 1 and 2](https://jorisvandenbossche.github.io/DS-python-geospatial/setup.html)
-1. Next, make sure to complete 3 and 4 of the [setup instructions](https://jorisvandenbossche.github.io/DS-python-geospatial/setup.html).
+0. If not already downloaded the course material, installed conda and setup the environment, see [setup instructions section 1 and 2](https://plovercode.github.io/DS-python-geospatial/setup.html)
+1. Next, make sure to complete 3 and 4 of the [setup instructions](https://plovercode.github.io/DS-python-geospatial/setup.html).
 
 > If you succesfully done all steps, put up your `green sticky note` on your laptop screen...
 
 Next:
 
-- Surf to and fill in [the questionnaire](https://hackmd.io/GaohdyaETeuUAI1F8sjXPw?both)
+- Surf to and fill in [the questionnaire](https://hackmd.io/1bcxgBFIRP28vgyMSZMaBg?both)
 - In Jupyter Lab, start with the 'notebooks/00-jupyter_introduction.ipynb'.
 
 > Installation or setup issues? Put up your `red sticky note` on your laptop screen.
@@ -115,9 +115,9 @@ class: middle, center
 
 ![:scale 80%](./static/img/issuetracker.png)
 
-Report bugs, typo's, suggestions... as issues ([New issue](https://github.com/jorisvandenbossche/course-python-geospatial/issues/new))
+Report bugs, typo's, suggestions... as issues ([New issue](https://github.com/plovercode/DS-python-geospatial/issues/new))
 
-or see the [contributing guidelines](https://github.com/jorisvandenbossche/course-python-geospatial/blob/main/CONTRIBUTING.md)
+or see the [contributing guidelines](https://plovercode.github.io/DS-python-geospatial/contributing.html)
 
 ---
 class: middle, section_background
@@ -221,7 +221,7 @@ class: center, middle
 
 ![:scale 100%](http://esq.h-cdn.co/assets/15/51/980x490/landscape-1450137389-john-cleese.JPG)
 
-### https://forms.gle/trjSSDhzD656j63LA
+### [Feedback Form](https://docs.google.com/forms/d/e/1FAIpQLSfiVYj-S0Z8BvCgWIbRORYKwCxiJ6Gcl3KuR1_XFPhgat_0Wg/viewform?usp=header)
 
 Please fill in the questionnaire.
 


### PR DESCRIPTION
Before sending out invites, we might need to reconsider the 
<img width="970" height="528" alt="image" src="https://github.com/user-attachments/assets/93123e94-72fa-44b2-8d68-90f062138a1c" />

As our notebooks will change during this final week, hence, it will require an update on git/download. Should I go back to the old version with the text file or do we have alternative method?